### PR TITLE
Fix cooldown day placeholder in messages

### DIFF
--- a/strategies/constants.py
+++ b/strategies/constants.py
@@ -10,8 +10,8 @@ TRY_COUNT = 3
 DAILY_NOTIFICATION = True # Write True to send a daily notification, False to only send notifications when the signal changes
 
 # main subjects
-MAIN_SIGNAL_CHANGE_LONG = f"GO LONG NOW (cooldown activated for {0} days)"
-MAIN_SIGNAL_CHANGE_SHORT = f"GO IN CASH NOW (cooldown activated for {0} days)"
+MAIN_SIGNAL_CHANGE_LONG = "GO LONG NOW (cooldown activated for {0} days)"
+MAIN_SIGNAL_CHANGE_SHORT = "GO IN CASH NOW (cooldown activated for {0} days)"
 COOLDOWN_WARNINGS = [1]
 COOLDOWN_WARNINGS_TEXT = ["Cooldown warning: Last day of cooldown"]
 


### PR DESCRIPTION
## Summary
- remove f-string prefix from cooldown alert message constants so `{0}` placeholder remains for later formatting

## Testing
- `python -m py_compile strategies/constants.py`
- `python - <<'PY'
import strategies.constants as c
print(c.MAIN_SIGNAL_CHANGE_LONG.format(c.COOLDOWN_DAYS))
print(c.MAIN_SIGNAL_CHANGE_SHORT.format(c.COOLDOWN_DAYS))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689b3685daf0832b859e7304d713763e